### PR TITLE
Fix assert! macro usage

### DIFF
--- a/core/src/recovery.rs
+++ b/core/src/recovery.rs
@@ -208,7 +208,7 @@ impl QuicRecovery {
         };
 
         assert!(
-            self.largest_sent_packet < seq
+            self.largest_sent_packet < seq,
             "cannot send packet older than last one"
         );
         self.largest_sent_packet = seq;


### PR DESCRIPTION
There is a bug in rustc that allows adding invalid trailing tokens to
the `assert!` macro call. They are currently ignored but are going to
produce errors in the future.

Fix assert! macro usage to add missing comma.

For more information, see
https://github.com/rust-lang/rust/issues/60024 and
https://github.com/rust-lang/rust/pull/60039